### PR TITLE
docs: Fix simple typo, usefull -> useful

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,5 +1,5 @@
 /**
- * Helpers file with usefull functions
+ * Helpers file with useful functions
  */
 
 const path = require('path'),


### PR DESCRIPTION
There is a small typo in lib/helpers.js.

Should read `useful` rather than `usefull`.

